### PR TITLE
Tweaked login redirect to go to requested page

### DIFF
--- a/server.js
+++ b/server.js
@@ -75,7 +75,7 @@ app.get('/login',
 app.post('/login', 
   passport.authenticate('local', { failureRedirect: '/login' }),
   function(req, res) {
-    res.redirect('/');
+    res.redirect(req.session.returnTo || '/');
   });
   
 app.get('/logout',


### PR DESCRIPTION
Used the functionality of the 'connect-ensure-login' module to get the page the user requested and redirect after login. Saves someone using this example from having to look up how to do this themselves.